### PR TITLE
Fix handle inheritance

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -60,6 +60,16 @@ pub(crate) struct SECURITY_ATTRIBUTES {
     bInheritHandle: BOOL,
 }
 
+impl SECURITY_ATTRIBUTES {
+    pub(crate) fn new(inherit_handles: bool) -> Self {
+        Self {
+            nLength: size_of::<SECURITY_ATTRIBUTES>() as DWORD,
+            lpSecurityDescriptor: null_mut(),
+            bInheritHandle: inherit_handles as BOOL,
+        }
+    }
+}
+
 // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow
 #[repr(C)]
 pub(crate) struct STARTUPINFOW {

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -8,6 +8,9 @@ pub(crate) const INFINITE: u32 = 0xFFFFFFFF;
 pub(crate) const WAIT_OBJECT_0: u32 = 0x00000000;
 // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess#remarks
 pub(crate) const STATUS_PENDING: u32 = 0x00000103;
+// https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-gethandleinformation#parameters
+#[cfg(test)]
+pub(crate) const HANDLE_FLAG_INHERIT: u32 = 0x00000001;
 
 // https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types#BOOL
 pub(crate) type BOOL = i32;
@@ -140,4 +143,7 @@ extern "system" {
     pub(crate) fn TerminateProcess(hProcess: HANDLE, uExitCode: UINT) -> BOOL;
     // https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
     pub(crate) fn WaitForSingleObject(hHandle: HANDLE, dwMilliseconds: DWORD) -> DWORD;
+    // https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-gethandleinformation
+    #[cfg(test)]
+    pub(crate) fn GetHandleInformation(hObject: HANDLE, lpdwFlags: PDWORD) -> BOOL;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,8 @@ use std::{
 
 use crate::binding::{
     CloseHandle, CreateProcessW, GetExitCodeProcess, TerminateProcess, WaitForSingleObject, BOOL,
-    DWORD, INFINITE, PCWSTR, PDWORD, PROCESS_INFORMATION, PWSTR, STARTUPINFOW, STATUS_PENDING,
-    UINT, WAIT_OBJECT_0,
+    DWORD, INFINITE, PCWSTR, PDWORD, PROCESS_INFORMATION, PWSTR, SECURITY_ATTRIBUTES, STARTUPINFOW,
+    STATUS_PENDING, UINT, WAIT_OBJECT_0,
 };
 
 /// A process builder, providing control over how a new process should be
@@ -287,6 +287,7 @@ impl Child {
     ) -> Result<Self, Error> {
         let mut startup_information = STARTUPINFOW::default();
         let mut process_information = PROCESS_INFORMATION::default();
+        let mut security_attributes = SECURITY_ATTRIBUTES::new(inherit_handles);
 
         startup_information.cb = size_of::<STARTUPINFOW>() as u32;
 
@@ -307,8 +308,8 @@ impl Child {
             CreateProcessW(
                 null(),
                 command.as_ptr() as PWSTR,
-                null_mut(),
-                null_mut(),
+                &mut security_attributes,
+                &mut security_attributes,
                 inherit_handles as BOOL,
                 process_creation_flags as DWORD,
                 null_mut(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,11 +287,22 @@ impl Child {
     ) -> Result<Self, Error> {
         let mut startup_information = STARTUPINFOW::default();
         let mut process_information = PROCESS_INFORMATION::default();
-        let mut security_attributes = SECURITY_ATTRIBUTES::new(inherit_handles);
 
         startup_information.cb = size_of::<STARTUPINFOW>() as u32;
 
         let process_creation_flags = 0 as DWORD;
+
+        // Skip allocation when `inherit_handles` is false.
+        let mut security_attributes;
+        let (lp_process_attributes, lp_thread_attributes) = if inherit_handles {
+            security_attributes = SECURITY_ATTRIBUTES::new(true);
+            (
+                &mut security_attributes as *mut SECURITY_ATTRIBUTES,
+                &mut security_attributes as *mut SECURITY_ATTRIBUTES,
+            )
+        } else {
+            (null_mut(), null_mut())
+        };
 
         let current_directory_ptr = current_directory
             .map(|path| {
@@ -308,8 +319,8 @@ impl Child {
             CreateProcessW(
                 null(),
                 command.as_ptr() as PWSTR,
-                &mut security_attributes,
-                &mut security_attributes,
+                lp_process_attributes,
+                lp_thread_attributes,
                 inherit_handles as BOOL,
                 process_creation_flags as DWORD,
                 null_mut(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,3 +545,58 @@ impl fmt::Display for ExitStatus {
         self.0.fmt(f)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binding::{GetHandleInformation, HANDLE_FLAG_INHERIT};
+    use std::ffi::c_void;
+
+    /// Returns true if the handle has HANDLE_FLAG_INHERIT set.
+    unsafe fn is_inheritable(handle: *mut c_void) -> bool {
+        let mut flags: DWORD = 0;
+        let ok = GetHandleInformation(handle, &mut flags) != 0;
+        assert!(ok, "GetHandleInformation failed");
+        (flags & HANDLE_FLAG_INHERIT) != 0
+    }
+
+    #[test]
+    fn default_spawn_does_not_give_inheritable_handles() {
+        let child = Command::new("cmd.exe /c exit 0").spawn().unwrap();
+        let hproc = child.process_information.hProcess;
+        let hthread = child.process_information.hThread;
+        // Check flags before waiting, since wait() closes the handles.
+        let proc_inheritable = unsafe { is_inheritable(hproc) };
+        let thread_inheritable = unsafe { is_inheritable(hthread) };
+        child.wait().unwrap();
+        assert!(
+            !proc_inheritable,
+            "process handle should NOT be inheritable by default"
+        );
+        assert!(
+            !thread_inheritable,
+            "thread handle should NOT be inheritable by default"
+        );
+    }
+
+    #[test]
+    fn inherit_handles_true_gives_inheritable_handles() {
+        let child = Command::new("cmd.exe /c exit 0")
+            .inherit_handles(true)
+            .spawn()
+            .unwrap();
+        let hproc = child.process_information.hProcess;
+        let hthread = child.process_information.hThread;
+        let proc_inheritable = unsafe { is_inheritable(hproc) };
+        let thread_inheritable = unsafe { is_inheritable(hthread) };
+        child.wait().unwrap();
+        assert!(
+            proc_inheritable,
+            "process handle should be inheritable when inherit_handles(true)"
+        );
+        assert!(
+            thread_inheritable,
+            "thread handle should be inheritable when inherit_handles(true)"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ pub struct Command {
 impl Command {
     /// Create a new [`Command`], with the following default configuration:
     ///
-    /// * Inherit handles of the calling process.
+    /// * Do not Inherit handles of the calling process.
     /// * Inherit the current drive and directory of the calling process.
     ///
     /// Builder methods are provided to change these defaults and otherwise
@@ -157,12 +157,16 @@ impl Command {
         }
     }
 
-    /// Enable/disable handles inherance.
+    /// Enable/disable handle inheritance.
     ///
-    /// If this parameter is `true`, each inheritable handle in the calling
-    /// process is inherited by the new process. If the parameter is `false`,
-    /// the handles are not inherited. Note that inherited handles have the
-    /// same value and access rights as the original handles.
+    /// When `true`, two things happen:
+    /// 1. Each inheritable handle in the calling process is inherited by the
+    ///    new process (maps to `bInheritHandles`).
+    /// 2. The process and thread handles returned in [`Child`] are themselves
+    ///    marked as inheritable, so *future* child processes can inherit them
+    ///    too (maps to `bInheritHandle` on `lpProcessAttributes` / `lpThreadAttributes`).
+    ///
+    /// When `false`, neither happens.
     ///
     /// Equivalent to the `bInheritHandles` parameter of the
     /// [`CreateProcessW`][create-process-w-parameters] function.


### PR DESCRIPTION
The handle inheritance might not work as expected at the moment.
This changes passes the `inherit_handles` parameter of the `Child::new()` function to the `SECURITY_ATTRIBUTES` struct so the handle can be created depending on the value of `inherit_handles`.